### PR TITLE
Replace chai with power assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Run `./client/fast-tdd.js` and enjoy blazing fast specs
 * Gulp
 * Webpack
 * Long term caching for assets (Cache-Busting)
-* Karma, mocha and Sinon.js
+* Karma, mocha, power-assert and Sinon.js
 * Istanbul test coverage
 * Protractor along with simple Page Objects
 * ESLint, HTMLHint

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Run `./client/fast-tdd.js` and enjoy blazing fast specs
 
 ## Features
 
-* AngularJS 1.5.x with ES2015 flavour
+* AngularJS 1.6.x with ES2015 flavour
 * AngularJS modules: uiRouter, ngResource, ngMessage, toastr and other useful stuff
 * Twitter Bootstrap with Sass
 * Gulp
 * Webpack
 * Long term caching for assets (Cache-Busting)
-* Karma, mocha, power-assert and Sinon.js
+* Karma, power-assert and Sinon.js
 * Istanbul test coverage
 * Protractor along with simple Page Objects
 * ESLint, HTMLHint

--- a/client/.babelrc
+++ b/client/.babelrc
@@ -5,11 +5,13 @@
   "plugins": ["angularjs-annotate"],
   "env": {
     "test": {
-      "plugins": [["istanbul", {
-        "exclude": [
-          "client/src/specs.js",
-          "client/src/**/*.spec.js"
-        ]
+      "presets": ["babel-preset-power-assert"],
+      "plugins": [
+        ["istanbul", {
+          "exclude": [
+            "client/src/specs.js",
+            "client/src/**/*.spec.js"
+          ]
       }]]
     }
   }

--- a/client/src/.eslintrc.json
+++ b/client/src/.eslintrc.json
@@ -22,6 +22,7 @@
     "angular/module-getter": "off",
     "angular/no-service-method": "off",
     "angular/on-watch": "off",
+    "angular/definedundefined": "off",
     "no-console": "error",
     "no-duplicate-imports": "error",
     "no-useless-rename": "error",

--- a/client/src/app/about/states/index/index.state.spec.js
+++ b/client/src/app/about/states/index/index.state.spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import assert from 'assert';
 import statesModule from '../states.module';
 
 describe(`module ${statesModule}`, () => {
@@ -16,7 +16,7 @@ describe(`module ${statesModule}`, () => {
     }));
 
     it('has valid url', inject(($state) => {
-      expect($state.href(state)).to.equal('#!/about');
+      assert.equal($state.href(state), '#!/about');
     }));
 
   });

--- a/client/src/app/app.module.spec.js
+++ b/client/src/app/app.module.spec.js
@@ -1,5 +1,5 @@
 import appModule from './app.module';
-import { expect } from 'chai';
+import assert from 'assert';
 import sinon from 'sinon';
 
 describe(`module ${appModule}`, () => {
@@ -14,14 +14,14 @@ describe(`module ${appModule}`, () => {
 
     it('changes the state to `404`', inject(($location, $rootScope, $state) => {
       // Given
-      expect($state.current.name).to.equal('');
+      assert.equal($state.current.name, '');
 
       // When
       $location.url('/unknown/url');
       $rootScope.$digest();
 
       // Then
-      expect($state.current.name).to.equal('404');
+      assert.equal($state.current.name, '404');
     }));
 
   });
@@ -36,11 +36,11 @@ describe(`module ${appModule}`, () => {
     }));
 
     it('logs the error', inject(($log) => {
-      expect($log.error.called).to.be.true;
+      assert($log.error.called);
     }));
 
     it('changes the state to `404`', inject(($state) => {
-      expect($state.go.calledWith('404')).to.be.true;
+      assert($state.go.calledWith('404'));
     }));
 
   });

--- a/client/src/app/bootstrap.spec.js
+++ b/client/src/app/bootstrap.spec.js
@@ -1,6 +1,6 @@
+import assert from 'assert';
 import { bootstrap } from './bootstrap';
 import commonsModule from './commons/commons.module';
-import { expect } from 'chai';
 import sinon from 'sinon';
 
 describe('boostrap', () => {
@@ -41,19 +41,19 @@ describe('boostrap', () => {
       }));
 
       it('configures the module', () => {
-        expect(app.constant.calledWith('appConfig', {
+        assert(app.constant.calledWith('appConfig', {
           environment: 'test'
-        })).to.be.true;
+        }));
       });
 
       it('boots the app', () => {
-        expect(angular.bootstrap.called).to.be.true;
+        assert(angular.bootstrap.called);
 
         const [el, modules, options] = angular.bootstrap.lastCall.args;
 
-        expect(el).to.equal('html');
-        expect(modules[0]).to.equal('app');
-        expect(options).to.have.property('strictDi', true);
+        assert.equal(el, 'html');
+        assert.equal(modules[0], 'app');
+        assert(options.strictDi);
       });
 
     });
@@ -72,7 +72,7 @@ describe('boostrap', () => {
         $httpBackend.flush();
 
         // Then
-        expect($log.error.called).to.be.true;
+        assert($log.error.called);
       }));
 
     });

--- a/client/src/app/commons/directives/unique-email/unique-email.directive.spec.js
+++ b/client/src/app/commons/directives/unique-email/unique-email.directive.spec.js
@@ -1,5 +1,5 @@
+import assert from 'assert';
 import directivesModule from '../directives.module';
-import { expect } from 'chai';
 
 describe(`module ${directivesModule}`, () => {
 
@@ -31,11 +31,8 @@ describe(`module ${directivesModule}`, () => {
     }));
 
     it('sets the correct debounce options', () => {
-      expect(scope.testForm.email.$options.getOption('debounce'))
-        .to.equal(300);
-
-      expect(scope.testForm.email.$options.getOption('updateOnDefault'))
-        .to.equal(true);
+      assert.equal(scope.testForm.email.$options.getOption('debounce'), 300);
+      assert(scope.testForm.email.$options.getOption('updateOnDefault'));
     });
 
     function setEmail(email) {
@@ -55,10 +52,10 @@ describe(`module ${directivesModule}`, () => {
         setEmail('taken@email.com');
         $httpBackend.flush();
 
-        expect(scope.testForm.$valid).to.be.false;
-        expect(scope.testForm.email.$valid).to.be.false;
-        expect(scope.testForm.email.$error).to.have.property('uniqueEmail', true);
-        expect(scope.contact.email).to.be.undefined;
+        assert(!scope.testForm.$valid);
+        assert(!scope.testForm.email.$valid);
+        assert(scope.testForm.email.$error.uniqueEmail);
+        assert.equal(scope.contact.email, undefined);
       });
 
     });
@@ -75,10 +72,10 @@ describe(`module ${directivesModule}`, () => {
         setEmail('test@email.com');
         $httpBackend.flush();
 
-        expect(scope.testForm.$valid).to.be.true;
-        expect(scope.testForm.email.$valid).to.be.true;
-        expect(scope.testForm.email.$error).to.not.have.property('uniqueEmail');
-        expect(scope.contact.email).to.equal('test@email.com');
+        assert(scope.testForm.$valid);
+        assert(scope.testForm.email.$valid);
+        assert(!scope.testForm.email.$error.uniqueEmail);
+        assert.equal(scope.contact.email, 'test@email.com');
       });
 
     });
@@ -106,10 +103,10 @@ describe(`module ${directivesModule}`, () => {
         setEmail('another@email.com');
         $httpBackend.flush();
 
-        expect(scope.testForm.$valid).to.be.false;
-        expect(scope.testForm.email.$valid).to.be.false;
-        expect(scope.testForm.email.$error).to.have.property('uniqueEmail', true);
-        expect(scope.contact.email).to.be.undefined;
+        assert(!scope.testForm.$valid);
+        assert(!scope.testForm.email.$valid);
+        assert(scope.testForm.email.$error.uniqueEmail);
+        assert.equal(scope.contact.email, undefined);
       });
 
     });

--- a/client/src/app/commons/filters/checkmark/checkmark.filter.spec.js
+++ b/client/src/app/commons/filters/checkmark/checkmark.filter.spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import assert from 'assert';
 import filtersModule from '../filters.module';
 
 describe(`module ${filtersModule}`, () => {
@@ -16,8 +16,8 @@ describe(`module ${filtersModule}`, () => {
     }));
 
     it('returns a checkmark', () => {
-      expect(filter(true)).to.equal('✓');
-      expect(filter(false)).to.equal('✘');
+      assert.equal(filter(true), '✓');
+      assert.equal(filter(false), '✘');
     });
 
   });

--- a/client/src/app/commons/services/alert/alert.service.spec.js
+++ b/client/src/app/commons/services/alert/alert.service.spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import assert from 'assert';
 import servicesModule from '../services.module';
 import sinon from 'sinon';
 
@@ -14,7 +14,7 @@ describe(`module ${servicesModule}`, () => {
 
     it('displays the message', inject(($window, alert) => {
       alert.show('The message');
-      expect($window.alert.calledWith('The message')).to.be.true;
+      assert($window.alert.calledWith('The message'));
     }));
 
   });

--- a/client/src/app/commons/services/confirmation/confirmation.service.spec.js
+++ b/client/src/app/commons/services/confirmation/confirmation.service.spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import assert from 'assert';
 import servicesModule from '../services.module';
 import sinon from 'sinon';
 
@@ -14,7 +14,7 @@ describe(`module ${servicesModule}`, () => {
 
     it('displays a confirmation', inject(($window, confirmation) => {
       confirmation.show('The message');
-      expect($window.confirm.calledWith('The message')).to.be.true;
+      assert($window.confirm.calledWith('The message'));
     }));
 
   });

--- a/client/src/app/contacts/components/contact-form/contact-form.component.spec.js
+++ b/client/src/app/contacts/components/contact-form/contact-form.component.spec.js
@@ -1,5 +1,5 @@
+import assert from 'assert';
 import componentsModule from '../components.module';
-import { expect } from 'chai';
 import sinon from 'sinon';
 
 describe(`module ${componentsModule}`, () => {
@@ -36,11 +36,11 @@ describe(`module ${componentsModule}`, () => {
       });
 
       it('initializes a contact copy', () => {
-        expect(ctrl.originalContact).to.not.be.undefined;
-        expect(ctrl.contact).to.not.be.undefined;
+        assert.notEqual(ctrl.originalContact, undefined);
+        assert(ctrl.contact);
 
-        expect(ctrl.contact).to.not.eq(ctrl.originalContact);
-        expect(ctrl.contact.id).to.equal(ctrl.originalContact.id);
+        assert.notEqual(ctrl.contact, ctrl.originalConcontact);
+        assert.equal(ctrl.contact.id, ctrl.originalContact.id);
       });
 
       describe('.showError', () => {
@@ -48,7 +48,7 @@ describe(`module ${componentsModule}`, () => {
         describe('when the form is not dirty', () => {
 
           it('returns false', () => {
-            expect(ctrl.showError({ $dirty: false })).to.be.false;
+            assert(!ctrl.showError({ $dirty: false }));
           });
 
         });
@@ -59,7 +59,7 @@ describe(`module ${componentsModule}`, () => {
 
             it('returns true', () => {
               const form = { $dirty: true, foo: { $invalid: true } };
-              expect(ctrl.showError(form, 'foo')).to.be.true;
+              assert(ctrl.showError(form, 'foo'));
             });
 
           });
@@ -68,7 +68,7 @@ describe(`module ${componentsModule}`, () => {
 
             it('returns false', () => {
               const form = { $dirty: true, foo: { $invalid: false } };
-              expect(ctrl.showError(form, 'foo')).to.be.false;
+              assert(!ctrl.showError(form, 'foo'));
             });
 
           });
@@ -81,12 +81,12 @@ describe(`module ${componentsModule}`, () => {
 
         it('returns true for a contacts with `id`', () => {
           angular.extend(ctrl.contact, { id: 123 });
-          expect(ctrl.isPersisted()).to.be.true;
+          assert(ctrl.isPersisted());
         });
 
         it('returns false for a contact without `id`', () => {
           angular.extend(ctrl.contact, { id: null });
-          expect(ctrl.isPersisted()).to.be.false;
+          assert(!ctrl.isPersisted());
         });
 
       });
@@ -95,22 +95,22 @@ describe(`module ${componentsModule}`, () => {
 
         it('updates a contact', () => {
           ctrl.submit();
-          expect(scope.update.calledWith(ctrl.contact)).to.be.true;
+          assert(scope.update.calledWith(ctrl.contact));
         });
 
         it('toggles `saving` flag', inject(($rootScope) => {
           // Given
-          expect(ctrl.saving).to.be.false;
+          assert(!ctrl.saving);
 
           // When
           ctrl.submit();
 
           // Then
-          expect(ctrl.saving).to.be.true;
+          assert(ctrl.saving);
 
           // ...resolve the promise
           $rootScope.$digest();
-          expect(ctrl.saving).to.be.false;
+          assert(!ctrl.saving);
         }));
 
       });

--- a/client/src/app/contacts/components/favourite-button/favourite-button.component.spec.js
+++ b/client/src/app/contacts/components/favourite-button/favourite-button.component.spec.js
@@ -1,5 +1,5 @@
+import assert from 'assert';
 import componentsModule from '../components.module';
-import { expect } from 'chai';
 import sinon from 'sinon';
 
 describe(`module ${componentsModule}`, () => {
@@ -39,7 +39,7 @@ describe(`module ${componentsModule}`, () => {
 
         it('toggles contact favourite flag', () => {
           buttonEl.click();
-          expect(scope.contact.toggleFavourite.called).to.be.true;
+          assert(scope.contact.toggleFavourite.called);
         });
 
         it('disabled and enabled the button', inject(($rootScope, $q) => {
@@ -47,20 +47,20 @@ describe(`module ${componentsModule}`, () => {
           const deferred = $q.defer();
           scope.contact.toggleFavourite.returns(deferred.promise);
 
-          expect(buttonEl.attr('disabled')).to.be.undefined;
+          assert.equal(buttonEl.attr('disabled'), undefined);
 
           // When
           buttonEl.click();
 
           // Then
-          expect(buttonEl.attr('disabled')).to.equal('disabled');
+          assert.equal(buttonEl.attr('disabled'), 'disabled');
 
           // When
           deferred.resolve();
           $rootScope.$digest();
 
           // Then
-          expect(buttonEl.attr('disabled')).to.be.undefined;
+          assert.equal(buttonEl.attr('disabled'), undefined);
         }));
 
       });
@@ -68,18 +68,14 @@ describe(`module ${componentsModule}`, () => {
       it('has valid star icon', () => {
         const iconEl = buttonEl.find('span');
 
-        expect(iconEl.hasClass('glyphicon-star-empty'))
-          .to.be.true;
-        expect(iconEl.hasClass('glyphicon-star'))
-          .to.be.false;
+        assert(iconEl.hasClass('glyphicon-star-empty'));
+        assert(!iconEl.hasClass('glyphicon-star'));
 
         angular.extend(scope.contact, { favourite: true });
         scope.$digest();
 
-        expect(iconEl.hasClass('glyphicon-star-empty'))
-          .to.be.false;
-        expect(iconEl.hasClass('glyphicon-star'))
-          .to.be.true;
+        assert(!iconEl.hasClass('glyphicon-star-empty'));
+        assert(iconEl.hasClass('glyphicon-star'));
       });
 
     });
@@ -102,17 +98,17 @@ describe(`module ${componentsModule}`, () => {
     }));
 
     it('has a `contact`', inject((Contact) => {
-      expect(ctrl.contact).to.be.an.instanceOf(Contact);
+      assert(ctrl.contact instanceof Contact);
     }));
 
     describe('.favourite', () => {
 
       it('returns `contact.favourite` flag', () => {
         angular.extend(ctrl.contact, { favourite: true });
-        expect(ctrl.favourite).to.be.true;
+        assert(ctrl.favourite);
 
         angular.extend(ctrl.contact, { favourite: false });
-        expect(ctrl.favourite).to.be.false;
+        assert(!ctrl.favourite);
       });
 
     });
@@ -121,20 +117,20 @@ describe(`module ${componentsModule}`, () => {
 
       it('updates a contact', () => {
         ctrl.toggleFavourite();
-        expect(ctrl.contact.toggleFavourite.called).to.be.true;
+        assert(ctrl.contact.toggleFavourite.called);
       });
 
       it('toggles `saving` flag', inject(($rootScope) => {
         // Given
-        expect(ctrl.saving).to.be.false;
+        assert(!ctrl.saving);
 
         // When
         ctrl.toggleFavourite();
-        expect(ctrl.saving).to.be.true;
+        assert(ctrl.saving);
         $rootScope.$digest();
 
         // Then
-        expect(ctrl.saving).to.be.false;
+        assert(!ctrl.saving);
       }));
 
     });

--- a/client/src/app/contacts/services/contact/contact.factory.spec.js
+++ b/client/src/app/contacts/services/contact/contact.factory.spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import assert from 'assert';
 import servicesModule from '../services.module';
 
 describe(`module ${servicesModule}`, () => {
@@ -17,16 +17,16 @@ describe(`module ${servicesModule}`, () => {
     }));
 
     it('has basic CRUD methods', () => {
-      expect(Contact.prototype).to.respondTo('$query');
-      expect(Contact.prototype).to.respondTo('$get');
-      expect(Contact.prototype).to.respondTo('$create');
-      expect(Contact.prototype).to.respondTo('$update');
-      expect(Contact.prototype).to.respondTo('$delete');
+      assert(Contact.prototype.$query instanceof Function);
+      assert(Contact.prototype.$get instanceof Function);
+      assert(Contact.prototype.$create instanceof Function);
+      assert(Contact.prototype.$update instanceof Function);
+      assert(Contact.prototype.$delete instanceof Function);
     });
 
     it('can be initialized', () => {
       const contact = new Contact({ id: 123 });
-      expect(contact).to.have.property('id', 123);
+      assert.equal(contact.id, 123);
     });
 
     describe('Contact.query', () => {
@@ -37,13 +37,13 @@ describe(`module ${servicesModule}`, () => {
           .respond(200, { contacts: [{ id: 1 }, { id: 2 }] });
 
         Contact.query().$promise.then((contacts) => {
-          expect(contacts).to.have.length(2);
+          assert.equal(contacts.length, 2);
 
-          expect(contacts[0]).to.be.an.instanceOf(Contact);
-          expect(contacts[0]).to.have.property('id', 1);
+          assert(contacts[0] instanceof Contact);
+          assert.equal(contacts[0].id, 1);
 
-          expect(contacts[1]).to.be.an.instanceOf(Contact);
-          expect(contacts[1]).to.have.property('id', 2);
+          assert(contacts[1] instanceof Contact);
+          assert.equal(contacts[1].id, 2);
 
           done();
         });
@@ -61,8 +61,8 @@ describe(`module ${servicesModule}`, () => {
           .respond(200, { id: 123, firstName: 'Luke' });
 
         Contact.get({ id: 123 }).$promise.then((contact) => {
-          expect(contact).to.have.property('id', 123);
-          expect(contact).to.have.property('firstName', 'Luke');
+          assert.equal(contact.id, 123);
+          assert.equal(contact.firstName, 'Luke');
 
           done();
         });
@@ -81,11 +81,11 @@ describe(`module ${servicesModule}`, () => {
 
         const contact = new Contact({ firstName: 'Luke' });
         contact.$create().then((createdContact) => {
-          expect(createdContact).to.equal(contact);
+          assert.equal(createdContact, contact);
 
-          expect(createdContact).to.be.an.instanceOf(Contact);
-          expect(createdContact).to.have.property('id', 123);
-          expect(createdContact).to.have.property('firstName', 'Luke');
+          assert(createdContact instanceof Contact);
+          assert.equal(createdContact.id, 123);
+          assert.equal(createdContact.firstName, 'Luke');
 
           done();
         });
@@ -99,7 +99,7 @@ describe(`module ${servicesModule}`, () => {
 
       it('returns the full name', () => {
         const contact = new Contact({ firstName: 'Luke', lastName: 'Skywalker' });
-        expect(contact.fullName).to.equal('Luke Skywalker');
+        assert.equal(contact.fullName, 'Luke Skywalker');
       });
 
     });
@@ -114,8 +114,8 @@ describe(`module ${servicesModule}`, () => {
         const contact = new Contact({ id: 126, favourite: false });
 
         contact.toggleFavourite().then((updatedContact) => {
-          expect(updatedContact).to.equal(contact);
-          expect(contact.favourite).to.be.true;
+          assert.equal(updatedContact, contact);
+          assert(contact.favourite);
 
           done();
         });

--- a/client/src/app/contacts/services/contact/contact.resolvers.spec.js
+++ b/client/src/app/contacts/services/contact/contact.resolvers.spec.js
@@ -1,5 +1,5 @@
 import { listResolver, oneResolver } from './contact.resolvers';
-import { expect } from 'chai';
+import assert from 'assert';
 import sinon from 'sinon';
 
 describe('contact.resolvers', () => {
@@ -16,7 +16,7 @@ describe('contact.resolvers', () => {
       listResolver(Contact);
 
       // Then
-      expect(Contact.query.called).to.be.true;
+      assert(Contact.query.called);
     });
 
   });
@@ -28,7 +28,7 @@ describe('contact.resolvers', () => {
       oneResolver({ id: 123 }, Contact);
 
       // Then
-      expect(Contact.get.calledWith({ id: 123 })).to.be.true;
+      assert(Contact.get.calledWith({ id: 123 }));
     });
 
   });

--- a/client/src/app/contacts/states/list/list.component.spec.js
+++ b/client/src/app/contacts/states/list/list.component.spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import assert from 'assert';
 import statesModule from '../states.module';
 
 describe(`module ${statesModule}`, () => {
@@ -23,16 +23,16 @@ describe(`module ${statesModule}`, () => {
     }));
 
     it('has an array of contacts', inject((Contact) => {
-      expect(ctrl.contacts).to.be.an('array');
-      expect(ctrl.contacts).to.have.length(2);
+      assert(ctrl.contacts instanceof Array);
+      assert.equal(ctrl.contacts.length, 2);
 
-      expect(ctrl.contacts[0]).to.be.an.instanceOf(Contact);
-      expect(ctrl.contacts[0]).to.have.property('id', 1);
-      expect(ctrl.contacts[0]).to.have.property('firstName', 'Karen');
+      assert(ctrl.contacts[0] instanceof Contact);
+      assert.equal(ctrl.contacts[0].id, 1);
+      assert.equal(ctrl.contacts[0].firstName, 'Karen');
 
-      expect(ctrl.contacts[1]).to.be.an.instanceOf(Contact);
-      expect(ctrl.contacts[1]).to.have.property('id', 2);
-      expect(ctrl.contacts[1]).to.have.property('firstName', 'Luke');
+      assert(ctrl.contacts[1] instanceof Contact);
+      assert.equal(ctrl.contacts[1].id, 2);
+      assert.equal(ctrl.contacts[1].firstName, 'Luke');
     }));
 
   });

--- a/client/src/app/contacts/states/list/list.state.spec.js
+++ b/client/src/app/contacts/states/list/list.state.spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import assert from 'assert';
 import sinon from 'sinon';
 import statesModule from '../states.module';
 
@@ -17,7 +17,7 @@ describe(`module ${statesModule}`, () => {
     }));
 
     it('has valid url', inject(($state) => {
-      expect($state.href(state)).to.equal('#!/contacts');
+      assert.equal($state.href(state), '#!/contacts');
     }));
 
     it('resolves `contacts`', (done) => {
@@ -32,16 +32,16 @@ describe(`module ${statesModule}`, () => {
 
         // When
         $resolve.resolve(state.resolve).then(({ contacts }) => {
-          expect(contacts).to.be.an('array');
-          expect(contacts).to.have.length(2);
+          assert(contacts instanceof Array);
+          assert.equal(contacts.length, 2);
 
-          expect(contacts[0]).to.be.instanceOf(Contact);
-          expect(contacts[0]).to.have.property('id', 10);
-          expect(contacts[0]).to.have.property('firstName', 'Anakin');
+          assert(contacts[0] instanceof Contact);
+          assert.equal(contacts[0].id, 10);
+          assert.equal(contacts[0].firstName, 'Anakin');
 
-          expect(contacts[1]).to.be.instanceOf(Contact);
-          expect(contacts[1]).to.have.property('id', 11);
-          expect(contacts[1]).to.have.property('firstName', 'Luke');
+          assert(contacts[1] instanceof Contact);
+          assert.equal(contacts[1].id, 11);
+          assert.equal(contacts[1].firstName, 'Luke');
 
           done();
         });

--- a/client/src/app/contacts/states/new/new.component.spec.js
+++ b/client/src/app/contacts/states/new/new.component.spec.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import assert from 'assert';
+import { isPromise } from '../../../../specs/utils';
 import sinon from 'sinon';
 import statesModule from '../states.module';
 
@@ -20,7 +21,7 @@ describe(`module ${statesModule}`, () => {
     }));
 
     it('has a contact', inject((Contact) => {
-      expect(ctrl.contact).to.be.an.instanceOf(Contact);
+      assert(ctrl.contact instanceof Contact);
     }));
 
     describe('.create', () => {
@@ -32,7 +33,7 @@ describe(`module ${statesModule}`, () => {
       }));
 
       it('returns a promise', () => {
-        expect(ctrl.create(contact)).to.be.a.promise;
+        assert(isPromise(ctrl.create(contact)));
       });
 
       describe('on success', () => {
@@ -50,17 +51,17 @@ describe(`module ${statesModule}`, () => {
         }));
 
         it('creates a contact', () => {
-          expect(ctrl.contact).to.have.property('id', 123);
-          expect(ctrl.contact).to.have.property('firstName', 'Luke');
-          expect(ctrl.contact).to.have.property('createdAt');
+          assert.equal(ctrl.contact.id, 123);
+          assert.equal(ctrl.contact.firstName, 'Luke');
+          assert(ctrl.contact.createdAt);
         });
 
         it('displays a notification', () => {
-          expect(ctrl.toastr.success.calledWith('Contact created')).to.be.true;
+          assert(ctrl.toastr.success.calledWith('Contact created'));
         });
 
         it('redirects to the show page', () => {
-          expect(ctrl.$state.go.calledWith('contacts.one.show')).to.be.true;
+          assert(ctrl.$state.go.calledWith('contacts.one.show'));
         });
 
       });
@@ -79,16 +80,15 @@ describe(`module ${statesModule}`, () => {
         }));
 
         it('does not create a contact', () => {
-          expect(ctrl.contact).to.not.have.property('id');
+          assert(!ctrl.contact.id);
         });
 
         it('does not redirect', () => {
-          expect(ctrl.$state.go.calledWith('contacts.one.show')).to.be.false;
+          assert(!ctrl.$state.go.calledWith('contacts.one.show'));
         });
 
         it('displays an error notification', () => {
-          expect(ctrl.toastr.error.calledWith('Unable to create a contact.'))
-            .to.be.true;
+          assert(ctrl.toastr.error.calledWith('Unable to create a contact.'));
         });
 
       });

--- a/client/src/app/contacts/states/new/new.state.spec.js
+++ b/client/src/app/contacts/states/new/new.state.spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import assert from 'assert';
 import statesModule from '../states.module';
 
 describe(`module ${statesModule}`, () => {
@@ -16,7 +16,7 @@ describe(`module ${statesModule}`, () => {
     }));
 
     it('has valid url', inject(($state) => {
-      expect($state.href(state)).to.equal('#!/contacts/new');
+      assert.equal($state.href(state), '#!/contacts/new');
     }));
 
   });

--- a/client/src/app/contacts/states/one/address/address.component.spec.js
+++ b/client/src/app/contacts/states/one/address/address.component.spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import assert from 'assert';
 import statesModule from '../../states.module';
 
 describe(`module ${statesModule}`, () => {
@@ -20,8 +20,8 @@ describe(`module ${statesModule}`, () => {
     }));
 
     it('has a contact', () => {
-      expect(ctrl.contact).to.have.property('id', 2);
-      expect(ctrl.contact).to.have.property('name', 'bar');
+      assert.equal(ctrl.contact.id, 2);
+      assert.equal(ctrl.contact.name, 'bar');
     });
 
   });

--- a/client/src/app/contacts/states/one/address/edit/edit.state.spec.js
+++ b/client/src/app/contacts/states/one/address/edit/edit.state.spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import assert from 'assert';
 import statesModule from '../../../states.module';
 
 describe(`module ${statesModule}`, () => {
@@ -16,8 +16,7 @@ describe(`module ${statesModule}`, () => {
     }));
 
     it('has valid url', inject(($state) => {
-      expect($state.href(state, { id: 123 }))
-        .to.equal('#!/contacts/123/address/edit');
+      assert.equal($state.href(state, { id: 123 }), '#!/contacts/123/address/edit');
     }));
 
   });

--- a/client/src/app/contacts/states/one/address/show/show.state.spec.js
+++ b/client/src/app/contacts/states/one/address/show/show.state.spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import assert from 'assert';
 import statesModule from '../../../states.module';
 
 describe(`module ${statesModule}`, () => {
@@ -16,7 +16,7 @@ describe(`module ${statesModule}`, () => {
     }));
 
     it('has valid url', inject(($state) => {
-      expect($state.href(state, { id: 123 })).to.equal('#!/contacts/123/address');
+      assert.equal($state.href(state, { id: 123 }), '#!/contacts/123/address');
     }));
 
   });

--- a/client/src/app/contacts/states/one/edit/edit.component.spec.js
+++ b/client/src/app/contacts/states/one/edit/edit.component.spec.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import assert from 'assert';
+import { isPromise } from '../../../../../specs/utils';
 import sinon from 'sinon';
 import statesModule from '../../states.module';
 
@@ -27,8 +28,8 @@ describe(`module ${statesModule}`, () => {
     }));
 
     it('has a contact', () => {
-      expect(ctrl.contact).to.have.property('id', 123);
-      expect(ctrl.contact).to.have.property('firstName', 'Anakin');
+      assert.equal(ctrl.contact.id, 123);
+      assert.equal(ctrl.contact.firstName, 'Anakin');
     });
 
     describe('.update', () => {
@@ -41,7 +42,7 @@ describe(`module ${statesModule}`, () => {
       });
 
       it('returns a promise', () => {
-        expect(ctrl.update(contact)).to.be.a.promise;
+        assert(isPromise(ctrl.update(contact)));
       });
 
       describe('on success', () => {
@@ -59,17 +60,17 @@ describe(`module ${statesModule}`, () => {
         }));
 
         it('updates a contact', () => {
-          expect(ctrl.contact).to.have.property('id', 123);
-          expect(ctrl.contact).to.have.property('firstName', 'Luke');
-          expect(ctrl.contact).to.have.property('updatedAt');
+          assert.equal(ctrl.contact.id, 123);
+          assert.equal(ctrl.contact.firstName, 'Luke');
+          assert(ctrl.contact.updatedAt);
         });
 
         it('displays a notification', () => {
-          expect(ctrl.toastr.success.calledWith('Contact updated')).to.be.true;
+          assert(ctrl.toastr.success.calledWith('Contact updated'));
         });
 
         it('redirects to the show page', () => {
-          expect(ctrl.$state.go.calledWith('contacts.one.show', { id: 123 })).to.be.true;
+          assert(ctrl.$state.go.calledWith('contacts.one.show', { id: 123 }));
         });
 
       });
@@ -88,17 +89,16 @@ describe(`module ${statesModule}`, () => {
         }));
 
         it('does not update a contact', () => {
-          expect(ctrl.contact).to.have.property('firstName', 'Anakin');
-          expect(ctrl.contact).to.not.have.property('createdAt');
+          assert.equal(ctrl.contact.firstName, 'Anakin');
+          assert(!ctrl.contact.createdAt);
         });
 
         it('does not redirect', () => {
-          expect(ctrl.$state.go.calledWith('contacts.one.show')).to.be.false;
+          assert(!ctrl.$state.go.calledWith('contacts.one.show'));
         });
 
         it('displays an error notification', () => {
-          expect(ctrl.toastr.error.calledWith('Unable to update a contact.'))
-            .to.be.true;
+          assert(ctrl.toastr.error.calledWith('Unable to update a contact.'));
         });
 
       });

--- a/client/src/app/contacts/states/one/edit/edit.state.spec.js
+++ b/client/src/app/contacts/states/one/edit/edit.state.spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import assert from 'assert';
 import statesModule from '../../states.module';
 
 describe(`module ${statesModule}`, () => {
@@ -16,7 +16,7 @@ describe(`module ${statesModule}`, () => {
     }));
 
     it('has valid url', inject(($state) => {
-      expect($state.href(state, { id: 124 })).to.equal('#!/contacts/124/edit');
+      assert.equal($state.href(state, { id: 124 }), '#!/contacts/124/edit');
     }));
 
   });

--- a/client/src/app/contacts/states/one/one.state.spec.js
+++ b/client/src/app/contacts/states/one/one.state.spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import assert from 'assert';
 import sinon from 'sinon';
 import statesModule from '../states.module';
 
@@ -26,11 +26,11 @@ describe(`module ${statesModule}`, () => {
 
         // When
         $resolve.resolve(state.resolve, { $stateParams }).then(({ contact }) => {
-          expect(Contact.get.calledWith({ id: 3 })).to.be.true;
+          assert(Contact.get.calledWith({ id: 3 }));
 
-          expect(contact).to.be.instanceOf(Contact);
-          expect(contact).to.have.property('id', 3);
-          expect(contact).to.have.property('name', 'baz');
+          assert(contact instanceof Contact);
+          assert.equal(contact.id, 3);
+          assert.equal(contact.name, 'baz');
 
           done();
         });

--- a/client/src/app/contacts/states/one/show/show.component.spec.js
+++ b/client/src/app/contacts/states/one/show/show.component.spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import assert from 'assert';
 import sinon from 'sinon';
 import statesModule from '../../states.module';
 
@@ -32,9 +32,9 @@ describe(`module ${statesModule}`, () => {
     }));
 
     it('has a contact', () => {
-      expect(ctrl.contact).to.have.property('id', 2);
-      expect(ctrl.contact).to.have.property('firstName', 'Anakin');
-      expect(ctrl.contact).to.have.property('lastName', 'Skywalker');
+      assert.equal(ctrl.contact.id, 2);
+      assert.equal(ctrl.contact.firstName, 'Anakin');
+      assert.equal(ctrl.contact.lastName, 'Skywalker');
     });
 
     describe('.delete', () => {
@@ -45,7 +45,7 @@ describe(`module ${statesModule}`, () => {
 
         // Then
         const message = 'Do you rally want to delete contact Anakin Skywalker?';
-        expect(ctrl.confirmation.show.calledWith(message)).to.be.true;
+        assert(ctrl.confirmation.show.calledWith(message));
       });
 
       describe('when confirmed', () => {
@@ -67,11 +67,11 @@ describe(`module ${statesModule}`, () => {
           }));
 
           it('displays a notification', () => {
-            expect(ctrl.toastr.success.calledWith('Contact deleted')).to.be.true;
+            assert(ctrl.toastr.success.calledWith('Contact deleted'));
           });
 
           it('redirect to the list page', () => {
-            expect(ctrl.$state.go.calledWith('contacts.list')).to.be.true;
+            assert(ctrl.$state.go.calledWith('contacts.list'));
           });
 
         });
@@ -89,12 +89,11 @@ describe(`module ${statesModule}`, () => {
           }));
 
           it('does not redirect', () => {
-            expect(ctrl.$state.go.calledWith('contacts.list')).to.be.false;
+            assert(!ctrl.$state.go.calledWith('contacts.list'));
           });
 
           it('displays an error notification', () => {
-            expect(ctrl.toastr.error.calledWith('Unable to delete a contact.'))
-              .to.be.true;
+            assert(ctrl.toastr.error.calledWith('Unable to delete a contact.'));
           });
 
         });
@@ -109,7 +108,7 @@ describe(`module ${statesModule}`, () => {
         });
 
         it('does nothing', () => {
-          expect(ctrl.$state.go.called).to.be.false;
+          assert(!ctrl.$state.go.called);
         });
 
       });

--- a/client/src/app/contacts/states/one/show/show.state.spec.js
+++ b/client/src/app/contacts/states/one/show/show.state.spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import assert from 'assert';
 import statesModule from '../../states.module';
 
 describe(`module ${statesModule}`, () => {
@@ -16,7 +16,7 @@ describe(`module ${statesModule}`, () => {
     }));
 
     it('has valid url', inject(($state) => {
-      expect($state.href(state, { id: 123 })).to.equal('#!/contacts/123');
+      assert.equal($state.href(state, { id: 123 }), '#!/contacts/123');
     }));
 
   });

--- a/client/src/app/home/states/index/index.component.spec.js
+++ b/client/src/app/home/states/index/index.component.spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import assert from 'assert';
 import sinon from 'sinon';
 import statesModule from '../states.module';
 
@@ -25,14 +25,14 @@ describe(`module ${statesModule}`, () => {
     }));
 
     it('has a message', () => {
-      expect(ctrl.message).to.equal('Hello World!');
+      assert.equal(ctrl.message, 'Hello World!');
     });
 
     describe('.sayHello', () => {
 
       it('alerts a message', () => {
         ctrl.sayHello();
-        expect(ctrl.alert.show.calledWith('Hello World!')).to.be.true;
+        assert(ctrl.alert.show.calledWith('Hello World!'));
       });
 
     });

--- a/client/src/app/home/states/index/index.state.spec.js
+++ b/client/src/app/home/states/index/index.state.spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import assert from 'assert';
 import statesModule from '../states.module';
 
 describe(`module ${statesModule}`, () => {
@@ -16,7 +16,7 @@ describe(`module ${statesModule}`, () => {
     }));
 
     it('has valid url', inject(($state) => {
-      expect($state.href(state)).to.equal('#!/');
+      assert.equal($state.href(state), '#!/');
     }));
 
   });

--- a/client/src/app/utils.spec.js
+++ b/client/src/app/utils.spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import assert from 'assert';
 import { extend } from './utils';
 
 describe('.extend', () => {
@@ -36,22 +36,22 @@ describe('.extend', () => {
 
   it('mixes instance methods', () => {
     const dolphin = new Dolphin('Willy');
-    expect(dolphin.breed()).to.equal('Willy is breeding');
+    assert.equal(dolphin.breed(), 'Willy is breeding');
   });
 
   it('calls the super method', () => {
     const dolphin = new Dolphin('Billy');
-    expect(dolphin.swim('the ocean')).to.equal('Billy is swimming in the ocean');
+    assert.equal(dolphin.swim('the ocean'), 'Billy is swimming in the ocean');
   });
 
   it('mixes instance properties', () => {
     const dolphin = new Dolphin('Willy');
 
     dolphin.speed = 20;
-    expect(dolphin.speedMiles).to.equal(12.4);
+    assert.equal(dolphin.speedMiles, 12.4);
 
     dolphin.speedMiles = 5;
-    expect(dolphin.speed).to.equal(8.064516129032258);
+    assert.equal(dolphin.speed, 8.064516129032258);
   });
 
 });

--- a/client/src/specs.js
+++ b/client/src/specs.js
@@ -1,23 +1,5 @@
 import 'angular';
 import 'angular-mocks';
-import chai from 'chai';
-
-function expectToBeAPromise(_chai) {
-  _chai.Assertion.addProperty('promise', function () {
-    const subject = this._obj;
-
-    const assertion = angular.isFunction(subject.then)
-      && angular.isFunction(subject.catch)
-      && angular.isFunction(subject.finally);
-
-    const expectedMessage = 'expected #{this} to be a promise';
-    const notExpectedMessage = 'expected #{this} not to be a promise';
-
-    this.assert(assertion, expectedMessage, notExpectedMessage);
-  });
-}
-
-chai.use(expectToBeAPromise);
 
 // Enable strictDi mode for all specs
 beforeEach(() => {

--- a/client/src/specs/utils.js
+++ b/client/src/specs/utils.js
@@ -1,0 +1,9 @@
+import assert from 'assert';
+
+export function isPromise(object) {
+  assert(object.then instanceof Function);
+  assert(object.catch instanceof Function);
+  assert(object.finally instanceof Function);
+
+  return true;
+}

--- a/client/webpack-test-fast.config.js
+++ b/client/webpack-test-fast.config.js
@@ -19,7 +19,7 @@ module.exports = {
       'angular-breadcrumb',
 
       'angular-mocks',
-      'chai',
+      'power-assert',
       'sinon'
     ],
     specs: './client/src/specs.js'
@@ -38,13 +38,15 @@ module.exports = {
     new webpack.optimize.CommonsChunkPlugin({
       name: 'vendor'
     }),
-    new webpack.NoErrorsPlugin(),
+    new webpack.NoEmitOnErrorsPlugin(),
     new ProgressBarPlugin({
       format: 'Webpack :msg [:bar] :percent'
     })
   ],
 
   module: {
+    exprContextCritical: false,
+
     rules: [{
       test: /\.js$/,
       exclude: /node_modules/,

--- a/client/webpack-test.config.js
+++ b/client/webpack-test.config.js
@@ -20,6 +20,8 @@ module.exports = function({ singleRun }) {
     ],
 
     module: {
+      exprContextCritical: false,
+
       rules: [{
         test: /\.js$/,
         exclude: /node_modules/,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -85,7 +85,8 @@ gulp.task('server:test', (done) => {
       gulp.src(['server/**/*.spec.js'], { read: false })
         .pipe(mocha({
           ui: 'bdd',
-          reporter: 'dot'
+          reporter: 'dot',
+          require: ['./server/enable-power-assert']
         }))
         .pipe(istanbul.writeReports({
           dir: 'artifacts/server/coverage',

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-plugin-angularjs-annotate": "0.7.0",
     "babel-plugin-istanbul": "4.1.1",
     "babel-preset-es2015": "6.24.0",
-    "chai": "3.5.0",
+    "babel-preset-power-assert": "1.0.0",
     "clean-webpack-plugin": "0.1.16",
     "concurrently": "3.4.0",
     "css-loader": "0.27.3",
@@ -36,6 +36,7 @@
     "eslint-plugin-mocha": "4.8.0",
     "eslint-plugin-promise": "3.4.1",
     "eslint-plugin-protractor": "1.34.1",
+    "espower-loader": "1.2.0",
     "extract-text-webpack-plugin": "2.1.0",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "0.10.1",
@@ -74,7 +75,7 @@
     "supertest": "3.0.0",
     "url-loader": "0.5.8",
     "webdriver-manager": "12.0.4",
-    "webpack": "2.3.1",
+    "webpack": "2.3.2",
     "webpack-dev-server": "2.4.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "node-sass": "4.5.1",
     "nodemon": "1.11.0",
     "null-loader": "0.1.1",
+    "power-assert": "1.4.2",
     "progress-bar-webpack-plugin": "1.9.3",
     "protractor": "5.1.1",
     "request": "2.81.0",

--- a/server/api/contacts.spec.js
+++ b/server/api/contacts.spec.js
@@ -1,4 +1,4 @@
-const expect = require('chai').expect;
+const assert = require('power-assert');
 const request = require('supertest');
 
 const app = require('../app');
@@ -33,11 +33,11 @@ describe('app', () => {
         .expect(200)
         .expect((res) => {
           const { contacts } = res.body;
-          expect(contacts).to.have.length(20);
+          assert(contacts.length === 20);
 
-          expect(contacts[0]).to.have.property('firstName', 'Wallace');
-          expect(contacts[0]).to.have.property('lastName', 'Rath');
-          expect(contacts[0]).to.have.property('email', 'Tessie_Carter16@gmail.com');
+          assert(contacts[0].firstName === 'Wallace');
+          assert(contacts[0].lastName === 'Rath');
+          assert(contacts[0].email === 'Tessie_Carter16@gmail.com');
         })
         .end(done);
     });
@@ -60,10 +60,10 @@ describe('app', () => {
         .expect((res) => {
           const { body: contact } = res;
 
-          expect(contact).to.have.property('id', 21);
-          expect(contact).to.have.property('firstName', firstName);
-          expect(contact).to.have.property('lastName', lastName);
-          expect(contact).to.have.property('email', email);
+          assert(contact.id === 21);
+          assert(contact.firstName === firstName);
+          assert(contact.lastName === lastName);
+          assert(contact.email === email);
         })
         .end(done);
     });
@@ -81,7 +81,7 @@ describe('app', () => {
             .get('/api/contacts/validate-email?email=luke@rebel.org')
             .expect(200)
             .expect((res) => {
-              expect(res.body).to.have.property('taken', false);
+              assert(!res.body.taken);
             })
             .end(done);
         });
@@ -101,7 +101,7 @@ describe('app', () => {
             .get(`/api/contacts/validate-email?email=${email}`)
             .expect(200)
             .expect((res) => {
-              expect(res.body).to.have.property('taken', true);
+              assert(res.body.taken);
             })
             .end(done);
         });
@@ -128,7 +128,7 @@ describe('app', () => {
             .get(`/api/contacts/validate-email?id=${id}email=${email}`)
             .expect(200)
             .expect((res) => {
-              expect(res.body).to.have.property('taken', false);
+              assert(!res.body.taken);
             })
             .end(done);
         });
@@ -138,7 +138,7 @@ describe('app', () => {
             .get(`/api/contacts/validate-email?id=${id}&email=tarkin@empire.com`)
             .expect(200)
             .expect((res) => {
-              expect(res.body).to.have.property('taken', false);
+              assert(!res.body.taken);
             })
             .end(done);
         });
@@ -158,7 +158,7 @@ describe('app', () => {
             .get(`/api/contacts/validate-email?id=${id}&email=${otherEmail}`)
             .expect(200)
             .expect((res) => {
-              expect(res.body).to.have.property('taken', true);
+              assert(res.body.taken);
             })
             .end(done);
         });
@@ -182,10 +182,10 @@ describe('app', () => {
           .expect((res) => {
             const { body: contact } = res;
 
-            expect(contact).to.have.property('id', 3);
-            expect(contact).to.have.property('firstName', 'Caterina');
-            expect(contact).to.have.property('lastName', 'Hackett');
-            expect(contact).to.have.property('email', 'Destin.Kassulke80@hotmail.com');
+            assert(contact.id === 3);
+            assert(contact.firstName === 'Caterina');
+            assert(contact.lastName === 'Hackett');
+            assert(contact.email === 'Destin.Kassulke80@hotmail.com');
           })
           .end(done);
       });
@@ -224,9 +224,9 @@ describe('app', () => {
           .expect((res) => {
             const { body: contact } = res;
 
-            expect(contact).to.have.property('id', id);
-            expect(contact).to.have.property('firstName', 'Luke');
-            expect(contact).to.have.property('lastName', 'Skywalker');
+            assert(contact.id === id);
+            assert(contact.firstName === 'Luke');
+            assert(contact.lastName === 'Skywalker');
           })
           .end(done);
       });

--- a/server/api/seed.spec.js
+++ b/server/api/seed.spec.js
@@ -1,4 +1,4 @@
-const expect = require('chai').expect;
+const assert = require('power-assert');
 const request = require('supertest');
 
 const app = require('../app');
@@ -14,7 +14,7 @@ describe('app', () => {
         .expect(200)
         .end(() => {
           db.contacts.find().then((contacts) => {
-            expect(contacts).to.have.length(20);
+            assert(contacts.length === 20);
             done();
           });
         });

--- a/server/collection.spec.js
+++ b/server/collection.spec.js
@@ -1,4 +1,4 @@
-const expect = require('chai').expect;
+const assert = require('power-assert');
 const Collection = require('./collection');
 const Promise = require('bluebird');
 
@@ -19,16 +19,16 @@ describe('Collection', () => {
     it('removes all documents', () => {
       return collection.drop().then(() => {
         return collection.find().then((documents) => {
-          expect(documents).to.have.length(0);
+          assert(documents.length === 0);
         });
       });
     });
 
     it('reset current id', () => {
       return collection.drop().then(() => {
-        expect(collection._nextId()).to.equal(1);
-        expect(collection._nextId()).to.equal(2);
-        expect(collection._nextId()).to.equal(3);
+        assert(collection._nextId() === 1);
+        assert(collection._nextId() === 2);
+        assert(collection._nextId() === 3);
       });
     });
 
@@ -45,7 +45,7 @@ describe('Collection', () => {
 
     it('returns all documents', () => {
       return collection.find().then((documents) => {
-        expect(documents).to.have.length(2);
+        assert(documents.length === 2);
       });
     });
 
@@ -63,8 +63,8 @@ describe('Collection', () => {
 
       it('resolves with the found document', () => {
         return collection.findOne({ email }).then((document) => {
-          expect(document).to.not.be.undefined;
-          expect(document).to.have.property('email', email);
+          assert(document);
+          assert(document.email === email);
         });
       });
 
@@ -87,11 +87,11 @@ describe('Collection', () => {
     it('inserts a document', () => {
       return collection.insertOne({ email: 'foo@email.com' }).then(() => {
         return collection.find().then((documents) => {
-          expect(documents).to.have.length(1);
-          expect(documents[0]).to.have.property('id');
-          expect(documents[0]).to.have.property('email', 'foo@email.com');
-          expect(documents[0]).to.have.property('updatedAt');
-          expect(documents[0]).to.have.property('createdAt');
+          assert(documents.length === 1);
+          assert(documents[0].id);
+          assert(documents[0].email === 'foo@email.com');
+          assert(documents[0].createdAt);
+          assert(documents[0].updatedAt);
         });
       });
     });
@@ -110,10 +110,10 @@ describe('Collection', () => {
 
     it('updates a document', () => {
       return collection.updateOne({ id }, { firstName: 'Luke' }).then((document) => {
-        expect(document).to.have.property('id', id);
-        expect(document).to.have.property('firstName', 'Luke');
-        expect(document).to.have.property('updatedAt');
-        expect(document).to.have.property('createdAt');
+        assert(document.id === id);
+        assert(document.firstName === 'Luke');
+        assert(document.updatedAt);
+        assert(document.createdAt);
       });
     });
 
@@ -132,7 +132,7 @@ describe('Collection', () => {
     it('deletes a document', () => {
       return collection.deleteOne({ id }).then(() => {
         return collection.find().then((documents) => {
-          expect(documents).to.have.length(0);
+          assert(documents.length === 0);
         });
       });
     });

--- a/server/db.spec.js
+++ b/server/db.spec.js
@@ -1,5 +1,5 @@
+const assert = require('power-assert');
 const db = require('./db');
-const expect = require('chai').expect;
 
 describe('db', () => {
 
@@ -9,11 +9,11 @@ describe('db', () => {
       return db.seed().then(() => {
         return db.contacts.find();
       }).then((contacts) => {
-        expect(contacts).to.have.length(20);
+        assert(contacts.length === 20);
 
-        expect(contacts[0]).to.have.property('id', 1);
-        expect(contacts[1]).to.have.property('id', 2);
-        expect(contacts[19]).to.have.property('id', 20);
+        assert(contacts[0].id === 1);
+        assert(contacts[1].id === 2);
+        assert(contacts[19].id === 20);
       });
     });
 
@@ -30,16 +30,16 @@ describe('db', () => {
         return db.contacts.find();
       })
       .then((contacts) => {
-        expect(contacts).to.have.length(0);
+        assert(contacts.length === 0);
       })
       .then(() => {
         return db.contacts.insertOne({ email: 'test@email.com' });
       })
       .then(() => {
         return db.contacts.find().then((contacts) => {
-          expect(contacts).to.have.length(1);
-          expect(contacts[0]).to.have.property('id', 1);
-          expect(contacts[0]).to.have.property('email', 'test@email.com');
+          assert(contacts.length === 1);
+          assert(contacts[0].id === 1);
+          assert(contacts[0].email === 'test@email.com');
         });
       });
     });

--- a/server/enable-power-assert.js
+++ b/server/enable-power-assert.js
@@ -1,0 +1,3 @@
+require('espower-loader')({
+  pattern: '**/*.spec.js'
+});

--- a/server/server.spec.js
+++ b/server/server.spec.js
@@ -1,4 +1,4 @@
-const expect = require('chai').expect;
+const assert = require('power-assert');
 const sinon = require('sinon');
 
 const app = require('./app');
@@ -25,8 +25,8 @@ describe('server', () => {
   it('seeds the db and starts the app', () => {
     require('./server');
 
-    expect(db.seed.called).to.be.true;
-    expect(app.listen.called).to.be.true;
+    assert(db.seed.called);
+    assert(app.listen.called);
   });
 
 });


### PR DESCRIPTION
- [x] power assert for the server app
- [x] power assert for the client app
- [ ] tune the default configuration
- [x] use `assert.equal`
- [x] setup wallaby for the server
- [ ] setup wallaby for the client
- [ ] macro for promises etc
- [x] improve readme.md
- [x] remove wallaby spike